### PR TITLE
BAH-2366 | Removed Brew based installations and updated Terraform and Plugin Versions

### DIFF
--- a/.github/workflows/nodegroups-deploy.yml
+++ b/.github/workflows/nodegroups-deploy.yml
@@ -16,6 +16,8 @@ on:
         options:
           - nonprod
           - performance
+env:
+  TERRAFORM_VERSION: 1.3.0
 jobs:
   provision-node-group:
     name: Provision Node Group
@@ -26,6 +28,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{env.TERRAFORM_VERSION}}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -2,7 +2,7 @@ name: Validate and Deploy to AWS
 
 on:
   push:
-    branches: [ main, BAH-2366 ]
+    branches: [ main ]
     paths-ignore:
       - 'README.md'
 env:
@@ -45,14 +45,11 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{env.TERRAFORM_VERSION}}
-      - name: Install TFSec
+      - name: Install tfsec and scan
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" 
           brew install tfsec
-          tfsec --version
           ./tfsec/tfsec.sh
-      # - name: TFSec
-      #   run: ./tfsec/tfsec.sh
 
   tfvalidate:
     name: Terraform Validate

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -50,8 +50,9 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" 
           brew install tfsec
           tfsec --version
-      - name: TFSec
-        run: ./tfsec/tfsec.sh
+          ./tfsec/tfsec.sh
+      # - name: TFSec
+      #   run: ./tfsec/tfsec.sh
 
   tfvalidate:
     name: Terraform Validate

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -2,7 +2,7 @@ name: Validate and Deploy to AWS
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, BAH-2336 ]
     paths-ignore:
       - 'README.md'
 env:

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -74,6 +74,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{env.TERRAFORM_VERSION}}
+          terraform_wrapper: false
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -88,9 +89,7 @@ jobs:
           cd terraform/
           terraform init -backend-config=config.s3.tfbackend -backend-config='key=nonprod/terraform.tfstate'
           terraform apply -var-file=nonprod.tfvars -auto-approve 
-          export CLUSTER_NAME=$(terraform output eks_cluster_name) && echo "printed cluster name here"
-          echo $CLUSTER_NAME && echo "checked env variable set or not"
-          echo "CLUSTER_NAME=$CLUSTER_NAME" >> $GITHUB_ENV && echo "error step"
+          echo "CLUSTER_NAME=$(terraform output -raw eks_cluster_name)" >> $GITHUB_ENV 
       - name: Setup Amazon EFS driver and StorageClass
         run: |
           export fileSystemId=$(aws ssm get-parameter --with-decryption --name "/nonprod/efs/file_system_id" --query "Parameter.Value" --output text)

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{env.TERRAFORM_VERSION}}
-      - name: Install Terrascan
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install terrascan
       - name: Terrascan scan and validate
         run: ./terrascan/terrascan.sh
   

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{env.TERRAFORM_VERSION}}
-      - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v2.0.1
+      - name: Install TFLint
+        run: curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
       - name: TFLint
         run: ./tflint/tflint.sh
         

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v1
+        uses: terraform-linters/setup-tflint@v2.0.1
       - name: TFLint
         run: ./tflint/tflint.sh
         

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -46,7 +46,10 @@ jobs:
         with:
           terraform_version: ${{env.TERRAFORM_VERSION}}
       - name: Install TFSec
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install tfsec
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" 
+          brew install tfsec
+          tfsec --version
       - name: TFSec
         run: ./tfsec/tfsec.sh
 

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -2,7 +2,7 @@ name: Validate and Deploy to AWS
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, BAH-2366 ]
     paths-ignore:
       - 'README.md'
 
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Add homebrew to path
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
       - name: Install Terrascan
         run: brew install terrascan
       - name: Terrascan scan and validate
@@ -28,12 +30,15 @@ jobs:
         uses: terraform-linters/setup-tflint@v1
       - name: TFLint
         run: ./tflint/tflint.sh
+        
   tfsec:
     name: TFSec
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Add homebrew to path
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
       - name: Install TFSec
         run: brew install tfsec
       - name: TFSec

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -2,7 +2,7 @@ name: Validate and Deploy to AWS
 
 on:
   push:
-    branches: [ main, BAH-2366 ]
+    branches: [ main ]
     paths-ignore:
       - 'README.md'
 env:

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Add homebrew to path
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      # - name: Add homebrew to path
+      #   run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
       - name: Install Terrascan
-        run: brew install terrascan
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install terrascan
       - name: Terrascan scan and validate
         run: ./terrascan/terrascan.sh
   
@@ -37,10 +37,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Add homebrew to path
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      # - name: Add homebrew to path
+      #   run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
       - name: Install TFSec
-        run: brew install tfsec
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install tfsec
       - name: TFSec
         run: ./tfsec/tfsec.sh
 

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -43,11 +43,10 @@ jobs:
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{env.TERRAFORM_VERSION}}
-      - name: Install tfsec and scan
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" 
-          brew install tfsec
-          ./tfsec/tfsec.sh
+      - name: Install tfsec
+        run: curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+      - name: tfsec
+        run: ./tfsec/tfsec.sh
 
   tfvalidate:
     name: Terraform Validate

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -5,7 +5,8 @@ on:
     branches: [ main, BAH-2366 ]
     paths-ignore:
       - 'README.md'
-
+env:
+  TERRAFORM_VERSION: 1.2.8
 jobs:
   terrascan:
     name: Terrascan
@@ -13,8 +14,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      # - name: Add homebrew to path
-      #   run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{env.TERRAFORM_VERSION}}
       - name: Install Terrascan
         run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install terrascan
       - name: Terrascan scan and validate
@@ -26,6 +28,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{env.TERRAFORM_VERSION}}
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v2.0.1
       - name: TFLint
@@ -37,8 +42,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      # - name: Add homebrew to path
-      #   run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{env.TERRAFORM_VERSION}}
       - name: Install TFSec
         run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew install tfsec
       - name: TFSec
@@ -61,6 +67,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{env.TERRAFORM_VERSION}}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -2,7 +2,7 @@ name: Validate and Deploy to AWS
 
 on:
   push:
-    branches: [ main, BAH-2336 ]
+    branches: [ main, BAH-2366 ]
     paths-ignore:
       - 'README.md'
 env:
@@ -88,7 +88,9 @@ jobs:
           cd terraform/
           terraform init -backend-config=config.s3.tfbackend -backend-config='key=nonprod/terraform.tfstate'
           terraform apply -var-file=nonprod.tfvars -auto-approve 
-          echo "CLUSTER_NAME=$(terraform output -raw eks_cluster_name)" >> $GITHUB_ENV
+          export CLUSTER_NAME=$(terraform output eks_cluster_name) && echo "printed cluster name here"
+          echo $CLUSTER_NAME && echo "checked env variable set or not"
+          echo "CLUSTER_NAME=$CLUSTER_NAME" >> $GITHUB_ENV && echo "error step"
       - name: Setup Amazon EFS driver and StorageClass
         run: |
           export fileSystemId=$(aws ssm get-parameter --with-decryption --name "/nonprod/efs/file_system_id" --query "Parameter.Value" --output text)

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - 'README.md'
 env:
-  TERRAFORM_VERSION: 1.2.8
+  TERRAFORM_VERSION: 1.3.0
 jobs:
   terrascan:
     name: Terrascan
@@ -56,6 +56,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{env.TERRAFORM_VERSION}} 
       - name: Terraform Validate
         run: ./terraform/tf-validate.sh
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.2.0"
+  required_version = "~>1.3.0"
 
   required_providers {
     aws = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.3.0"
+  required_version = "~>1.2.8"
 
   required_providers {
     aws = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,12 +3,12 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.2.8"
+  required_version = "~>1.3.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.9.0"
+      version = "4.32.0"
     }
   }
 

--- a/terraform/node_groups/nonprod/main.tf
+++ b/terraform/node_groups/nonprod/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.2.0"
+  required_version = "~>1.3.0"
 
   required_providers {
     aws = {

--- a/terraform/node_groups/nonprod/main.tf
+++ b/terraform/node_groups/nonprod/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.3.0"
+  required_version = "~>1.2.8"
 
   required_providers {
     aws = {

--- a/terraform/node_groups/nonprod/main.tf
+++ b/terraform/node_groups/nonprod/main.tf
@@ -3,12 +3,12 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.2.8"
+  required_version = "~>1.3.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.9.0"
+      version = "4.32.0"
     }
   }
 

--- a/terraform/node_groups/performance/main.tf
+++ b/terraform/node_groups/performance/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.2.0"
+  required_version = "~>1.3.0"
 
   required_providers {
     aws = {

--- a/terraform/node_groups/performance/main.tf
+++ b/terraform/node_groups/performance/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.3.0"
+  required_version = "~>1.2.8"
 
   required_providers {
     aws = {

--- a/terraform/node_groups/performance/main.tf
+++ b/terraform/node_groups/performance/main.tf
@@ -3,12 +3,12 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~>1.2.8"
+  required_version = "~>1.3.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.9.0"
+      version = "4.32.0"
     }
   }
 

--- a/terrascan/terrascan.sh
+++ b/terrascan/terrascan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Terrascan scan and save output to scan_results
-scan_results="$(terrascan scan --config-path terrascan/terrascan-config.yaml --iac-type terraform --use-colors t)"
+scan_results="$(docker run -v `pwd`:`pwd` -w `pwd` accurics/terrascan scan --config-path terrascan/terrascan-config.yaml --iac-type terraform --use-colors t)"
 
 # Get scan summary from scan_results
 scan_summary=$(echo "$scan_results" | sed -n -e '/Scan Summary -/,$p' | sed -r "s/[[:cntrl:]]\[([0-9]{1,3};)*[0-9]{1,3}m//g")

--- a/tflint/.tflint.hcl
+++ b/tflint/.tflint.hcl
@@ -4,7 +4,7 @@ config {
 
 plugin "aws" {
     enabled = true
-    version = "0.13.3"
+    version = "0.17.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/tflint/tflint.sh
+++ b/tflint/tflint.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-
+export TFLINT_LOG=debug tflint
 set -e
 REL_SCRIPT_DIR="`dirname \"$0\"`"
 SCRIPT_DIR="`( cd \"$REL_SCRIPT_DIR\" && pwd)`"
 # sourcing git hub actions common script
 source $SCRIPT_DIR/../.github/gha_common.sh
-
 run_scan(){
     folder=$1
 
@@ -13,8 +12,8 @@ run_scan(){
     terraform_init
 
     echo -e "${GREEN_COLOR}TFLint Scanning $folder....$NO_COLOR"
-    tflint --config=$SCRIPT_DIR/.tflint.hcl --loglevel=info --init
-    tflint --config=$SCRIPT_DIR/.tflint.hcl --loglevel=info
+    tflint --config=$SCRIPT_DIR/.tflint.hcl --init
+    tflint --config=$SCRIPT_DIR/.tflint.hcl
 
     if [[ $? -eq 0 ]]
     then

--- a/tflint/tflint.sh
+++ b/tflint/tflint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TFLINT_LOG=debug tflint
+export TFLINT_LOG=debug
 set -e
 REL_SCRIPT_DIR="`dirname \"$0\"`"
 SCRIPT_DIR="`( cd \"$REL_SCRIPT_DIR\" && pwd)`"

--- a/tfsec/tfsec.yml
+++ b/tfsec/tfsec.yml
@@ -6,4 +6,4 @@ exclude:
   - aws-vpc-no-public-egress-sgr              # External access by instances to the internet
   - aws-vpc-no-public-ingress-sgr             # Public access from anywhere to bastion host
   - aws-iam-enforce-mfa
-  - map_public_ip_on_launch                   # Subnet associates public IP address
+  - aws-ec2-no-public-ip-subnet                  # Subnet associates public IP address

--- a/tfsec/tfsec.yml
+++ b/tfsec/tfsec.yml
@@ -6,3 +6,4 @@ exclude:
   - aws-vpc-no-public-egress-sgr              # External access by instances to the internet
   - aws-vpc-no-public-ingress-sgr             # Public access from anywhere to bastion host
   - aws-iam-enforce-mfa
+  - map_public_ip_on_launch                   # Subnet associates public IP address


### PR DESCRIPTION
- TFLint is now installed using Bash Script
- TFlint aws plugin version upgraded up to 0.17.0
- Terrascan now runs on a Docker Container
- tfsec is now  installed using Bash Script
- Terraform version upgraded up to 1.3.0
- AWS provider version upgraded to to 4.32.0